### PR TITLE
Optionally use a whitelist of config on exporting.

### DIFF
--- a/drush_cmi_tools.drush.inc
+++ b/drush_cmi_tools.drush.inc
@@ -27,6 +27,9 @@ function drush_cmi_tools_drush_command() {
       'ignore-list' => [
         'description' => 'Path to YAML file containing config to ignore from exports',
       ],
+      'partial-list' => [
+        'description' => 'Path to YAML file containing config to exclusively export',
+      ],
     ],
     'examples' => [
       'drush config-export-plus --destination=/some/folder --ignore-list=./config-ignore.yml' => 'Export configuration; Save files in a backup directory named config-export.',
@@ -75,7 +78,8 @@ function drush_drush_cmi_tools_config_export_plus($destination = NULL) {
   } else {
     return drush_log(dt('You must provide a --destination option'), LogLevel::ERROR);
   }
-  $patterns = [];
+  $patterns = ['ignore' => [], 'partial' => []];
+  // Parse ignore list.
   if ($ignore_list = drush_get_option('ignore-list')) {
     if (!is_file($ignore_list)) {
       return drush_log(dt('The file specified in --ignore-list option does not exist.'), LogLevel::ERROR);
@@ -100,14 +104,56 @@ function drush_drush_cmi_tools_config_export_plus($destination = NULL) {
         if (substr($ignore, -4) === '.yml') {
           $ignore = substr($ignore, 0, -4);
         }
-        $patterns[] =  '/' . str_replace('\*', '(.*)', preg_quote($ignore)) . '\.yml/';
+        $patterns['ignore'][] = '/' . str_replace('\*', '(.*)', preg_quote($ignore)) . '\.yml/';
+      }
+    }
+  }
+  // Parse partial list.
+  if ($partial_list = drush_get_option('partial-list')) {
+    if (!is_file($partial_list)) {
+      return drush_log(dt('The file specified in --partial-list option does not exist.'), LogLevel::ERROR);
+    }
+    if ($string = file_get_contents($partial_list)) {
+      $partial_list_error = FALSE;
+      $parsed = FALSE;
+      try {
+        $parsed = Yaml::decode($string);
+      }
+      catch (InvalidDataTypeException $e) {
+        $partial_list_error = TRUE;
+      }
+      if (!isset($parsed['config']) || !is_array($parsed['config'])) {
+        $partial_list_error = TRUE;
+      }
+      if ($partial_list_error) {
+        return drush_log(dt('The file specified in --partial-list option is in the wrong format. It must be valid YAML with a top-level config key.'), LogLevel::ERROR);
+      }
+      foreach ($parsed['config'] as $config) {
+        // Allow for accidental .yml extension.
+        if (substr($config, -4) === '.yml') {
+          $config = substr($config, 0, -4);
+        }
+        $patterns['partial'][] = '/' . str_replace('\*', '(.*)', preg_quote($config)) . '\.yml/';
       }
     }
   }
 
   $result = _drush_config_export($destination, $destination_dir, FALSE);
   $file_service =  \Drupal::service('file_system');
-  foreach ($patterns as $pattern) {
+
+  if (!empty($patterns['partial'])) {
+    $matches = array();
+    foreach ($patterns['partial'] as $pattern) {
+      $matches += file_scan_directory($destination_dir, $pattern);
+    }
+    $all_files = file_scan_directory($destination_dir, '/.*\.yml/');
+    foreach (array_diff_key($all_files, $matches) as $file_url => $file) {
+      $file_service->unlink($file_url);
+      drush_log("Removed $file_url according to partial list.", LogLevel::OK);
+    }
+  }
+
+  foreach ($patterns['ignore'] as $pattern) {
     foreach (file_scan_directory($destination_dir, $pattern) as $file_url => $file) {
       $file_service->unlink($file_url);
       drush_log("Removed $file_url according to ignore list.", LogLevel::OK);


### PR DESCRIPTION
The --ignore-list option is very handy for excluding config you know about, but I reckon just as important a use case is for only including config you want to manage (i.e. whitelisting config as opposed to blacklisting as currently). For example, a client might set up a new view, vocabulary, image style, or node type, and you might allow that, but you can't necessarily know the config they've created in order to add it to your ignore list. 
Instead, in this workflow, you actually only care about managing a known list of config, so an option could be used to switch the cexy command to only export that config that matches against that list?

I reckon a new option could be used to get this suggested whitelisting behaviour:

```
--partial-list=/path/to/file
```

Setting both a partial-list and an ignore-list would mean only things in the partial list and not in the ignore list get exported. Or could anyone suggest a better way of defining/naming the options?

(Originally raised as https://github.com/previousnext/drush_cmi_tools/issues/2)
