### PR TITLE
Correct path matching

### DIFF
--- a/drush_cmi_tools.drush.inc
+++ b/drush_cmi_tools.drush.inc
@@ -100,7 +100,7 @@ function drush_drush_cmi_tools_config_export_plus($destination = NULL) {
         if (substr($ignore, -4) === '.yml') {
           $ignore = substr($ignore, 0, -4);
         }
-        $patterns[] =  '/' . str_replace('\*', '(.*)', preg_quote($ignore)) . '\.yml/';
+        $patterns[] =  '/^' . str_replace('\*', '(.*)', preg_quote($ignore)) . '\.yml/';
       }
     }
   }


### PR DESCRIPTION
Added caret so that items in the ignore list start with that specific path for correct path matching. I have a scenario where:

`ignore:`
`  - webform.*`

Would result in this yml file being removed:

`core.entity_form_display.paragraph.webform.default.yml`

It would match anything with it which I'm sure is not intentional. Therefore, as it's not possible to add this to the ignore path itself it was simplest to just prepend in the file scan patterns variable. Although you could extend your code to allow these more complex patterns.

Just thought I'd commit this in case this may be useful for anyone having the same issue.