### PR TITLE
Support the ignore of config collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ignore:
   - system.site
   - workbench_email.workbench_email_template.*
 ignore_collection:
-	- language.sw
+  - language.sw
 ```
 
 You'll note there are some wildcards there. We're ignoring all contact message fields and forms as well as any form or view display configuration. Additionally we're ignoring [Workbench Email](https://drupal.org/project/workbench_email) templates and the system site settings in addition to excluding the Swedish language collection.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Its like `drush cex` but with 74% more shiny<sup>[1](#ref1)</sup>.
 
 So the normal `drush cex` command comes with a `--skip-modules` option that prevents configuration from say devel module from being exported. But let's go back to our original use case.
 
-We want to export all configuration, but we want to exclude certain patterns.
+We want to export all configuration, but we want to exclude certain patterns or collections.
 
 This is where the `--ignore-list` option of `drush cexy` comes in.
 
@@ -33,9 +33,11 @@ ignore:
   - core.entity_view_display.contact_form*
   - system.site
   - workbench_email.workbench_email_template.*
+ignore_collection:
+	- language.sw
 ```
 
-You'll note there are some wildcards there. We're ignoring all contact message fields and forms as well as any form or view display configuration. Additionally we're ignoring [Workbench Email](https://drupal.org/project/workbench_email) templates and the system site settings.
+You'll note there are some wildcards there. We're ignoring all contact message fields and forms as well as any form or view display configuration. Additionally we're ignoring [Workbench Email](https://drupal.org/project/workbench_email) templates and the system site settings in addition to excluding the Swedish language collection.
 
 So now we run `drush cexy` like so
 

--- a/drush_cmi_tools.drush.inc
+++ b/drush_cmi_tools.drush.inc
@@ -74,6 +74,7 @@ function drush_drush_cmi_tools_config_export_plus($destination = NULL) {
     return drush_log(dt('You must provide a --destination option'), LogLevel::ERROR);
   }
   $patterns = [];
+  $collections = [];
   if ($ignore_list = drush_get_option('ignore-list')) {
     if (!is_file($ignore_list)) {
       return drush_log(dt('The file specified in --ignore-list option does not exist.'), LogLevel::ERROR);
@@ -87,24 +88,40 @@ function drush_drush_cmi_tools_config_export_plus($destination = NULL) {
       catch (InvalidDataTypeException $e) {
         $ignore_list_error = TRUE;
       }
-      if (!isset($parsed['ignore']) || !is_array($parsed['ignore'])) {
+      if (!isset($parsed['ignore']) || !is_array($parsed['ignore']) || !isset($parsed['ignore_collection']) || !is_array($parsed['ignore_collection'])) {
         $ignore_list_error = TRUE;
       }
       if ($ignore_list_error) {
-        return drush_log(dt('The file specified in --ignore-list option is in the wrong format. It must be valid YAML with a top-level ignore key.'), LogLevel::ERROR);
+        return drush_log(dt('The file specified in --ignore-list option is in the wrong format. It must be valid YAML with a top-level ignore and ignore_collection key.'), LogLevel::ERROR);
       }
       foreach ($parsed['ignore'] as $ignore) {
         // Allow for accidental .yml extension.
         if (substr($ignore, -4) === '.yml') {
           $ignore = substr($ignore, 0, -4);
         }
-        $patterns[] =  '/^' . str_replace('\*', '(.*)', preg_quote($ignore)) . '\.yml/';
+        $patterns[] = '/^' . str_replace('\*', '(.*)', preg_quote($ignore)) . '\.yml/';
+      }
+      foreach ($parsed['ignore_collection'] as $ignore) {
+        $collections[] = str_replace('.', '/', $ignore);
       }
     }
   }
 
   $result = _drush_config_export($destination, $destination_dir, FALSE);
-  $file_service =  \Drupal::service('file_system');
+  foreach ($collections as $collection_dir) {
+    $collection_path = $destination_dir . '/' . $collection_dir;
+    if (is_dir($collection_path)) {
+      file_unmanaged_delete_recursive($collection_path);
+      drush_log("Removed $collection_path collection according to ignore list.", LogLevel::OK);
+    }
+    $collection_directories = explode('/', $collection_dir);
+    $collection_root_dir = $destination_dir . '/' . reset($collection_directories);
+    if (is_dir($collection_root_dir) && (count(scandir($collection_root_dir)) == 2)) {
+      file_unmanaged_delete_recursive($collection_root_dir);
+    }
+  }
+
+  $file_service = \Drupal::service('file_system');
   foreach ($patterns as $pattern) {
     foreach (file_scan_directory($destination_dir, $pattern) as $file_url => $file) {
       $file_service->unlink($file_url);


### PR DESCRIPTION
We have a situation where we wish to ignore entire collections. An example would be having languages turned on but we don't necessarily want this all to be exported to config. Currently there is now way to ignore those with the file_scan_directory method using patterns. So I have added an additional option to specify a collection to ignore.

Example:
```
ignore_collection:
  - language.sw
```

Would ignore and remove the Swedish language collection and also remove the collection root directory if empty.

Have also fixed a few formatting issues where there were two spaces instead of one after the equals sign.