### PR TITLE
Allow using it with drush 9.x.

### DIFF
--- a/drush_cmi_tools.drush.inc
+++ b/drush_cmi_tools.drush.inc
@@ -4,12 +4,13 @@
  * @file
  * Contains turbo-charged config commands for a better partial workflow.
  */
+
 use Drupal\Component\Serialization\Exception\InvalidDataTypeException;
 use Drupal\Component\Serialization\Yaml;
 use Drupal\config\StorageReplaceDataWrapper;
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Config\StorageComparer;
-use Drush\Config\StorageWrapper;
+use Drush\Drupal\Commands\config\ConfigCommands;
 use Drush\Log\LogLevel;
 
 /**
@@ -103,7 +104,7 @@ function drush_drush_cmi_tools_config_export_plus($destination = NULL) {
     }
   }
 
-  $result = _drush_config_export($destination, $destination_dir, FALSE);
+  $result = \Drupal::service('config.export.commands')->doExport($destination, $destination_dir, FALSE);
   $file_service =  \Drupal::service('file_system');
   foreach ($patterns as $pattern) {
     foreach (file_scan_directory($destination_dir, $pattern) as $file_url => $file) {
@@ -194,7 +195,7 @@ function drush_drush_cmi_tools_config_import_plus($destination = NULL) {
     foreach ($storage_comparer->getAllCollectionNames() as $collection) {
       $change_list[$collection] = $storage_comparer->getChangelist(NULL, $collection);
     }
-    _drush_print_config_changes_table($change_list);
+    ConfigCommands::configChangesTablePrint($change_list);
   }
   else {
     // Copy active storage to the temporary directory.
@@ -212,6 +213,6 @@ function drush_drush_cmi_tools_config_import_plus($destination = NULL) {
   }
 
   if (drush_confirm(dt('Import the listed configuration changes?'))) {
-    return drush_op('_drush_config_import', $storage_comparer);
+    \Drupal::service('config.import.commands')->doImport($storage_comparer);
   }
 }


### PR DESCRIPTION
You can't do this 
```
composer require "drupal/core": "^8.4@beta" "drush/drush": "~8.1"
```
You can only do 

```
composer require "drupal/core": "^8.4@beta" "drush/drush": "^9.0@beta"
```
This can be a new branch imo. I'm not sure it should be called 8.x-2.x or 9.